### PR TITLE
fix: only add .replace when a path is used

### DIFF
--- a/packages/architect/lib/src/generators/dart_client.dart
+++ b/packages/architect/lib/src/generators/dart_client.dart
@@ -232,9 +232,11 @@ class DartClient extends Generator {
               .property('parse')
               .invoke([const Static('baseUrl')]);
 
-          uri = uri //
-              .property('replace')
-              .invoke([Literal.of(path).named('path')]);
+          if (path.isNotEmpty && path != '/') {
+            uri = uri //
+                .property('replace')
+                .invoke([Literal.of(path).named('path')]);
+          }
 
           if (query.isNotEmpty) {
             uri = uri //


### PR DESCRIPTION
closes #35